### PR TITLE
Fix multiline support

### DIFF
--- a/pnotes.sty
+++ b/pnotes.sty
@@ -70,9 +70,13 @@
     \expandarg%
     \StrSubstitute{\unexpanded{#1}}{\unexpanded{\par}}{\unexpanded{\\\\}}[\rRest]
     \StrCut{\rRest}{\unexpanded{\\}}\rFirst\rRest%
-    \whiledo{\not\equal{\rFirst\rRest}{}}{%
+    \StrLen{\rFirst}[\lenFirst]
+    \StrLen{\rRest}[\lenRest]
+    \whiledo{\lenFirst > 0 \or \lenRest > 0}{%
         \immediate\write\pdfpcnotesfile{- \rFirst}%
         \StrCut{\rRest}{\unexpanded{\\}}\rFirst\rRest%
+        \StrLen{\rFirst}[\lenFirst]
+        \StrLen{\rRest}[\lenRest]
     }
 
     \pnotelastframe=\value{framenumber}


### PR DESCRIPTION
\pnote{a\\b\\c\\d} works now as intended.
Previously the comparison died when more than one \\ was given in the input.
