### PR TITLE
Latex seems to missinterpret \or sometimes - exchanged for \OR

### DIFF
--- a/pnotes.sty
+++ b/pnotes.sty
@@ -72,7 +72,7 @@
     \StrCut{\rRest}{\unexpanded{\\}}\rFirst\rRest%
     \StrLen{\rFirst}[\lenFirst]
     \StrLen{\rRest}[\lenRest]
-    \whiledo{\lenFirst > 0 \or \lenRest > 0}{%
+    \whiledo{\lenFirst > 0 \OR \lenRest > 0}{%
         \immediate\write\pdfpcnotesfile{- \rFirst}%
         \StrCut{\rRest}{\unexpanded{\\}}\rFirst\rRest%
         \StrLen{\rFirst}[\lenFirst]

--- a/pnotes.sty
+++ b/pnotes.sty
@@ -1,10 +1,4 @@
-
-
-
-% http://tex.stackexchange.com/questions/119191/extract-all-note-tags-from-beamer-as-a-simple-text-file
-
-
-
+% This is based upon http://tex.stackexchange.com/questions/119191/extract-all-note-tags-from-beamer-as-a-simple-text-file
 
 \NeedsTeXFormat{LaTeX2e}[1994/06/01]
 \ProvidesPackage{pnotes}[2014/11/02 PDFPC Notes]


### PR DESCRIPTION
See http://texdoc.net/texmf-dist/doc/latex/base/ifthen.pdf in the introduction.
